### PR TITLE
Feat add evaluator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,24 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
-name = "enum-as-inner"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,17 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]
@@ -83,7 +54,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn",
 ]
 
 [[package]]
@@ -97,6 +68,5 @@ name = "vondel"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "enum-as-inner",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.71"
-enum-as-inner = "0.5.1"
 thiserror = "1.0.40"

--- a/src/inter.rs
+++ b/src/inter.rs
@@ -1,4 +1,7 @@
 mod ast;
+mod environment;
+mod evaluator;
 mod lexer;
+mod object;
 pub mod repl;
 mod tokens;

--- a/src/inter/ast.rs
+++ b/src/inter/ast.rs
@@ -1,8 +1,8 @@
 use super::tokens::TokenType;
 use anyhow::{bail, Error, Result};
 use thiserror::Error;
-mod expression;
-use expression::Expression;
+pub mod expression;
+pub use expression::Expression;
 
 #[derive(Error, Debug, PartialEq)]
 enum ParserError {

--- a/src/inter/ast.rs
+++ b/src/inter/ast.rs
@@ -70,7 +70,7 @@ pub struct Program {
     pub errors: Vec<Error>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum StatementType {
     Let { name: Expression, value: Expression },
     Return(Expression),

--- a/src/inter/ast.rs
+++ b/src/inter/ast.rs
@@ -162,6 +162,15 @@ impl<'a> Parser<'a> {
         Expression::new_boolean(self.cur_token)
     }
 
+    fn get_current_identifier(&self) -> Result<String> {
+        match self.cur_token {
+            TokenType::Ident(s) => Ok(s.clone()),
+            _ => bail!(ParserError::IllegalToken {
+                tok: self.cur_token.clone()
+            }),
+        }
+    }
+
     fn parse_prefix_expression(&mut self) -> Result<Expression> {
         let op = self.cur_token;
         self.next_token();
@@ -227,13 +236,13 @@ impl<'a> Parser<'a> {
             return Ok(params);
         }
 
-        let ident = self.parse_identifier_expression(self.cur_token.as_ident().unwrap())?;
+        let ident = self.parse_identifier_expression(&self.get_current_identifier()?)?;
         params.push(ident);
 
         while self.peek_token_is(TokenType::Comma) {
             self.next_token();
             self.next_token();
-            let ident = self.parse_identifier_expression(self.cur_token.as_ident().unwrap())?;
+            let ident = self.parse_identifier_expression(&self.get_current_identifier()?)?;
             params.push(ident);
         }
 
@@ -334,11 +343,9 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_let_statement(&mut self) -> Result<StatementType> {
-        let res = self
-            .expect_peek(TokenType::Ident(String::new()))?
-            .as_ident()
-            .unwrap();
-        let name = Expression::Identifier(res.to_string());
+        self.expect_peek(TokenType::Ident(String::new()))?;
+        let ident = self.get_current_identifier()?;
+        let name = Expression::Identifier(ident);
 
         self.expect_peek(TokenType::Assign)?;
         self.next_token();

--- a/src/inter/ast/expression.rs
+++ b/src/inter/ast/expression.rs
@@ -11,15 +11,6 @@ pub enum PrefixOp {
     Minus,
 }
 
-impl PrefixOp {
-    pub fn type_as_string(&self) -> &'static str {
-        match self {
-            PrefixOp::Bang => "!",
-            PrefixOp::Minus => "-",
-        }
-    }
-}
-
 #[derive(Debug, PartialEq, Clone)]
 pub enum InfixOp {
     Plus,

--- a/src/inter/ast/expression.rs
+++ b/src/inter/ast/expression.rs
@@ -5,7 +5,7 @@ use anyhow::{bail, Result};
 use super::StatementType;
 use crate::inter::tokens::TokenType;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum PrefixOp {
     Bang,
     Minus,
@@ -20,7 +20,7 @@ impl PrefixOp {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum InfixOp {
     Plus,
     Minus,
@@ -63,7 +63,7 @@ impl fmt::Display for InfixOp {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Expression {
     Identifier(String),
     Integer(i64),

--- a/src/inter/ast/expression.rs
+++ b/src/inter/ast/expression.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use anyhow::{bail, Result};
 
 use super::StatementType;
@@ -7,6 +9,15 @@ use crate::inter::tokens::TokenType;
 pub enum PrefixOp {
     Bang,
     Minus,
+}
+
+impl PrefixOp {
+    pub fn type_as_string(&self) -> &'static str {
+        match self {
+            PrefixOp::Bang => "!",
+            PrefixOp::Minus => "-",
+        }
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -19,6 +30,37 @@ pub enum InfixOp {
     NotEqual,
     LessThan,
     GreaterThan,
+}
+
+impl InfixOp {
+    pub fn type_as_string(&self) -> &'static str {
+        match self {
+            InfixOp::Plus => "+",
+            InfixOp::Minus => "-",
+            InfixOp::Asterisk => "*",
+            InfixOp::Slash => "/",
+            InfixOp::Equal => "==",
+            InfixOp::NotEqual => "!=",
+            InfixOp::LessThan => "<",
+            InfixOp::GreaterThan => ">",
+        }
+    }
+}
+
+impl fmt::Display for InfixOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let buf = match self {
+            InfixOp::Plus => "+",
+            InfixOp::Minus => "-",
+            InfixOp::Asterisk => "*",
+            InfixOp::Slash => "/",
+            InfixOp::Equal => "==",
+            InfixOp::NotEqual => "!=",
+            InfixOp::LessThan => "<",
+            InfixOp::GreaterThan => ">",
+        };
+        write!(f, "{}", buf)
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -51,6 +93,18 @@ pub enum Expression {
 }
 
 impl Expression {
+    pub fn type_as_string(&self) -> &'static str {
+        match self {
+            Expression::Identifier(_) => "Identifier",
+            Expression::Integer(_) => "Integer",
+            Expression::Prefix { .. } => "Prefix",
+            Expression::Infix { .. } => "Infix",
+            Expression::Boolean(_) => "Boolean",
+            Expression::If { .. } => "If",
+            Expression::FunctionLiteral { .. } => "FunctionLiteral",
+            Expression::Call { .. } => "Call",
+        }
+    }
     pub fn new_ident(ident: &String) -> Self {
         Expression::Identifier(String::from(ident))
     }

--- a/src/inter/environment.rs
+++ b/src/inter/environment.rs
@@ -1,0 +1,73 @@
+use anyhow::{bail, Result};
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
+
+use crate::inter::{ast::Expression, evaluator::EvaluationError};
+
+use super::object::Object;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Environment {
+    store: HashMap<String, Object>,
+    outer: Option<Rc<RefCell<Environment>>>,
+}
+
+impl Environment {
+    pub fn new() -> Self {
+        Environment {
+            store: HashMap::new(),
+            outer: None,
+        }
+    }
+
+    pub fn new_with_outer(outer: Rc<RefCell<Environment>>) -> Self {
+        Environment {
+            store: HashMap::new(),
+            outer: Some(outer),
+        }
+    }
+
+    pub fn set_arguments_to_env(
+        &mut self,
+        args: Vec<Object>,
+        params: Vec<Expression>,
+    ) -> Result<()> {
+        for (idx, arg) in args.into_iter().enumerate() {
+            let name = self.get_name(&params[idx])?;
+            self.store.insert(name, arg);
+        }
+
+        Ok(())
+    }
+
+    fn get_name(&self, name: &Expression) -> Result<String> {
+        let name = match name {
+            Expression::Identifier(s) => s,
+            _ => bail!(EvaluationError::ExpectedIdentifier {
+                found: name.type_as_string()
+            }),
+        };
+        Ok(name.to_string())
+    }
+
+    pub fn get(&self, name: &str) -> Result<Object> {
+        let res = match self.store.get(name) {
+            Some(o) => o,
+            None => match self.outer {
+                Some(ref outer_env) => {
+                    let outer_env = outer_env.borrow();
+                    return outer_env.get(name);
+                }
+                None => bail!(EvaluationError::IdentifierNotFound {
+                    identifier: name.to_string()
+                }),
+            },
+        };
+        Ok(res.clone())
+    }
+
+    pub fn set(&mut self, name: &Expression, value: Object) -> Result<()> {
+        let name = self.get_name(name)?;
+        self.store.insert(name, value);
+        Ok(())
+    }
+}

--- a/src/inter/evaluator.rs
+++ b/src/inter/evaluator.rs
@@ -1,0 +1,1010 @@
+use crate::inter::{ast::Program, environment::Environment};
+
+use super::ast;
+use super::object::Object;
+use anyhow::Result;
+use thiserror::Error;
+
+mod custom;
+pub mod rust;
+
+const TRUE: Object = Object::Boolean(true);
+const FALSE: Object = Object::Boolean(false);
+const NULL: Object = Object::Null;
+
+#[derive(Debug, Error, PartialEq)]
+pub enum EvaluationError {
+    #[error("Unexpected object to invert signal: '{obj}, object must be an Integer")]
+    MissingIntegerToInvert { obj: &'static str },
+
+    #[error("Mismatched types in infix expression: expected 'Integer' and 'Integer' for '{operator}', found '{left} and '{right}'")]
+    MismatchedTypesInfix {
+        left: &'static str,
+        right: &'static str,
+        operator: &'static str,
+    },
+
+    #[error("Unexpected boolean operator '{operator}' for 'Boolean' and 'Boolean', must be '==', '!=', '&&' or '||'")]
+    UnallowedBooleanComparisonOperator { operator: &'static str },
+
+    #[error("Identifier not found: '{identifier}'")]
+    IdentifierNotFound { identifier: String },
+
+    #[error("Expected Identifier Expression found: '{found}'")]
+    ExpectedIdentifier { found: &'static str },
+
+    #[error("Wrong number of arguments: found '{found}' expected '{expected}'")]
+    WrongNumberOfArguments { found: usize, expected: usize },
+
+    #[error("Expected function found: '{found}'")]
+    NotAFunction { found: &'static str },
+}
+
+pub(crate) trait Evaluator {
+    fn eval(&self, node: &Program, env: &mut Environment) -> Result<Object>;
+}
+
+#[cfg(test)]
+mod test {
+    use std::{cell::RefCell, rc::Rc};
+
+    use crate::inter::{
+        ast::expression::{InfixOp, PrefixOp},
+        environment::Environment,
+        tokens::TokenType,
+    };
+
+    use super::*;
+    use ast::*;
+
+    fn test_eval_program(eval: &dyn Evaluator, prog: &ast::Program) -> Result<Object> {
+        let mut e = Environment::new();
+        let res = eval.eval(prog, &mut e)?;
+        println!("e: {:?}", e);
+        Ok(res)
+    }
+
+    fn create_program(ast: Vec<ast::StatementType>) -> ast::Program {
+        ast::Program {
+            statements: ast,
+            errors: vec![],
+        }
+    }
+
+    #[test]
+    fn eval_integer_expression() -> Result<()> {
+        // 5
+        // 10
+        // -5
+        // -10
+        // 5 * 2 - 10
+        // 5 + 2 * 10
+        // 20 + 2*-10
+        // 2 * (5 + 10)
+        // (5 + 10 * 2 + 15 / 3) * 2 + -10
+        let ast = vec![
+            StatementType::Expression(Expression::Integer(5)),
+            StatementType::Expression(Expression::Integer(10)),
+            StatementType::Expression(Expression::Prefix {
+                op: PrefixOp::Minus,
+                right: Box::new(Expression::Integer(5)),
+            }),
+            StatementType::Expression(Expression::Prefix {
+                op: PrefixOp::Minus,
+                right: Box::new(Expression::Integer(10)),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Infix {
+                    left: Box::new(Expression::Integer(5)),
+                    op: InfixOp::Asterisk,
+                    right: Box::new(Expression::Integer(2)),
+                }),
+                op: InfixOp::Plus,
+                right: Box::new(Expression::Integer(10)),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Integer(5)),
+                op: InfixOp::Plus,
+                right: Box::new(Expression::Infix {
+                    left: Box::new(Expression::Integer(2)),
+                    op: InfixOp::Asterisk,
+                    right: Box::new(Expression::Integer(10)),
+                }),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Integer(20)),
+                op: InfixOp::Plus,
+                right: Box::new(Expression::Infix {
+                    left: Box::new(Expression::Integer(2)),
+                    op: InfixOp::Asterisk,
+                    right: Box::new(Expression::Prefix {
+                        op: PrefixOp::Minus,
+                        right: Box::new(Expression::Integer(10)),
+                    }),
+                }),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Integer(2)),
+                op: InfixOp::Asterisk,
+                right: Box::new(Expression::Infix {
+                    left: Box::new(Expression::Integer(5)),
+                    op: InfixOp::Plus,
+                    right: Box::new(Expression::Integer(10)),
+                }),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Infix {
+                    left: Box::new(Expression::Infix {
+                        left: Box::new(Expression::Infix {
+                            left: Box::new(Expression::Integer(5)),
+                            op: InfixOp::Plus,
+                            right: Box::new(Expression::Infix {
+                                left: Box::new(Expression::Integer(10)),
+                                op: InfixOp::Asterisk,
+                                right: Box::new(Expression::Integer(2)),
+                            }),
+                        }),
+                        op: InfixOp::Plus,
+                        right: Box::new(Expression::Infix {
+                            left: Box::new(Expression::Integer(15)),
+                            op: InfixOp::Slash,
+                            right: Box::new(Expression::Integer(3)),
+                        }),
+                    }),
+                    op: InfixOp::Asterisk,
+                    right: Box::new(Expression::Integer(2)),
+                }),
+                op: InfixOp::Plus,
+                right: Box::new(Expression::Prefix {
+                    op: PrefixOp::Minus,
+                    right: Box::new(Expression::Integer(10)),
+                }),
+            }),
+        ];
+
+        let results = vec![5, 10, -5, -10, 20, 25, 0, 30, 50];
+
+        let rust_eval = rust::RustEvaluator::new();
+
+        for (idx, node) in ast.into_iter().enumerate() {
+            let rust_res = test_eval_program(&rust_eval, &create_program(vec![node]))?;
+            assert_eq!(rust_res.inspect(), results[idx].to_string())
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn eval_boolean_expression() -> Result<()> {
+        /* true
+         * false
+         * 1 < 2
+         * 1 > 2
+         * 1 < 1
+         * 1 > 1
+         * 1 == 1
+         * 1 != 1
+         * 1 == 2
+         * 1 != 2
+         * true == true
+         * false == false
+         * true == false
+         * true != false
+         * false != true
+         */
+        let ast = vec![
+            StatementType::Expression(Expression::Boolean(true)),
+            StatementType::Expression(Expression::Boolean(false)),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Integer(1)),
+                op: InfixOp::LessThan,
+                right: Box::new(Expression::Integer(2)),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Integer(1)),
+                op: InfixOp::GreaterThan,
+                right: Box::new(Expression::Integer(2)),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Integer(1)),
+                op: InfixOp::LessThan,
+                right: Box::new(Expression::Integer(1)),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Integer(1)),
+                op: InfixOp::GreaterThan,
+                right: Box::new(Expression::Integer(1)),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Integer(1)),
+                op: InfixOp::Equal,
+                right: Box::new(Expression::Integer(1)),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Integer(1)),
+                op: InfixOp::NotEqual,
+                right: Box::new(Expression::Integer(1)),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Integer(1)),
+                op: InfixOp::Equal,
+                right: Box::new(Expression::Integer(2)),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Integer(1)),
+                op: InfixOp::NotEqual,
+                right: Box::new(Expression::Integer(2)),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Boolean(true)),
+                op: InfixOp::Equal,
+                right: Box::new(Expression::Boolean(true)),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Boolean(false)),
+                op: InfixOp::Equal,
+                right: Box::new(Expression::Boolean(false)),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Boolean(true)),
+                op: InfixOp::Equal,
+                right: Box::new(Expression::Boolean(false)),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Boolean(true)),
+                op: InfixOp::NotEqual,
+                right: Box::new(Expression::Boolean(false)),
+            }),
+            StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Boolean(false)),
+                op: InfixOp::NotEqual,
+                right: Box::new(Expression::Boolean(true)),
+            }),
+        ];
+
+        let results = vec![
+            true, false, true, false, false, false, true, false, false, true, true, true, false,
+            true, true,
+        ];
+        let rust_eval = rust::RustEvaluator::new();
+
+        for (idx, node) in ast.into_iter().enumerate() {
+            let rust_res = test_eval_program(&rust_eval, &create_program(vec![node]))?;
+            assert_eq!(rust_res.inspect(), results[idx].to_string())
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn eval_bang_operator() -> Result<()> {
+        let ast = vec![
+            StatementType::Expression(
+                Expression::new_prefix(&TokenType::Bang, Expression::Boolean(true)).unwrap(),
+            ),
+            StatementType::Expression(
+                Expression::new_prefix(&TokenType::Bang, Expression::Boolean(false)).unwrap(),
+            ),
+            StatementType::Expression(
+                Expression::new_prefix(&TokenType::Bang, Expression::Integer(5)).unwrap(),
+            ),
+            StatementType::Expression(
+                Expression::new_prefix(
+                    &TokenType::Bang,
+                    Expression::new_prefix(&TokenType::Bang, Expression::Boolean(true)).unwrap(),
+                )
+                .unwrap(),
+            ),
+            StatementType::Expression(
+                Expression::new_prefix(
+                    &TokenType::Bang,
+                    Expression::new_prefix(&TokenType::Bang, Expression::Boolean(false)).unwrap(),
+                )
+                .unwrap(),
+            ),
+            StatementType::Expression(
+                Expression::new_prefix(
+                    &TokenType::Bang,
+                    Expression::new_prefix(&TokenType::Bang, Expression::Integer(5)).unwrap(),
+                )
+                .unwrap(),
+            ),
+        ];
+
+        let results = vec![false, true, false, true, false, true];
+        let rust_eval = rust::RustEvaluator::new();
+
+        for (idx, node) in ast.into_iter().enumerate() {
+            let rust_res = test_eval_program(&rust_eval, &create_program(vec![node]))?;
+            assert_eq!(rust_res.inspect(), results[idx].to_string())
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn eval_if_else_statements() -> Result<()> {
+        /*
+         * if (true) { 10 }
+         * if (false) { 10 }
+         * if (1) { 10 }
+         * if (1 < 2) { 10 }
+         * if (1 > 2) { 10 }
+         * if (1 > 2) { 10 } else { 20 }
+         * if (1 < 2) { 10 } else { 20 }
+         */
+        let ast = vec![
+            StatementType::Expression(Expression::If {
+                condition: Box::new(Expression::Boolean(true)),
+                consequence: Box::new(StatementType::Block(vec![StatementType::Expression(
+                    Expression::Integer(10),
+                )])),
+                alternative: None,
+            }),
+            StatementType::Expression(Expression::If {
+                condition: Box::new(Expression::Boolean(false)),
+                consequence: Box::new(StatementType::Block(vec![StatementType::Expression(
+                    Expression::Integer(10),
+                )])),
+                alternative: None,
+            }),
+            StatementType::Expression(Expression::If {
+                condition: Box::new(Expression::Integer(1)),
+                consequence: Box::new(StatementType::Block(vec![StatementType::Expression(
+                    Expression::Integer(10),
+                )])),
+                alternative: None,
+            }),
+            StatementType::Expression(Expression::If {
+                condition: Box::new(Expression::Infix {
+                    left: Box::new(Expression::Integer(1)),
+                    op: InfixOp::LessThan,
+                    right: Box::new(Expression::Integer(2)),
+                }),
+                consequence: Box::new(StatementType::Block(vec![StatementType::Expression(
+                    Expression::Integer(10),
+                )])),
+                alternative: None,
+            }),
+            StatementType::Expression(Expression::If {
+                condition: Box::new(Expression::Infix {
+                    left: Box::new(Expression::Integer(1)),
+                    op: InfixOp::GreaterThan,
+                    right: Box::new(Expression::Integer(2)),
+                }),
+                consequence: Box::new(StatementType::Block(vec![StatementType::Expression(
+                    Expression::Integer(10),
+                )])),
+                alternative: None,
+            }),
+            StatementType::Expression(Expression::If {
+                condition: Box::new(Expression::Infix {
+                    left: Box::new(Expression::Integer(1)),
+                    op: InfixOp::GreaterThan,
+                    right: Box::new(Expression::Integer(2)),
+                }),
+                consequence: Box::new(StatementType::Block(vec![StatementType::Expression(
+                    Expression::Integer(10),
+                )])),
+                alternative: Some(Box::new(StatementType::Block(vec![
+                    StatementType::Expression(Expression::Integer(20)),
+                ]))),
+            }),
+            StatementType::Expression(Expression::If {
+                condition: Box::new(Expression::Infix {
+                    left: Box::new(Expression::Integer(1)),
+                    op: InfixOp::LessThan,
+                    right: Box::new(Expression::Integer(2)),
+                }),
+                consequence: Box::new(StatementType::Block(vec![StatementType::Expression(
+                    Expression::Integer(10),
+                )])),
+                alternative: Some(Box::new(StatementType::Block(vec![
+                    StatementType::Expression(Expression::Integer(20)),
+                ]))),
+            }),
+        ];
+
+        let results = vec![
+            10.to_string(),
+            NULL.to_string(),
+            10.to_string(),
+            10.to_string(),
+            NULL.to_string(),
+            20.to_string(),
+            10.to_string(),
+        ];
+
+        let rust_eval = rust::RustEvaluator::new();
+
+        for (idx, node) in ast.into_iter().enumerate() {
+            let rust_res = test_eval_program(&rust_eval, &create_program(vec![node]))?;
+            assert_eq!(rust_res.inspect(), results[idx].to_string())
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn eval_return_statements() -> Result<()> {
+        /*
+         * return 1;
+         * return 2; 9;
+         * return 2 * 3; 9;
+         * 9; return 4 * 5; 9;
+         * if (10 > 1) {
+         *     if (10 > 1) {
+         *         return 100;
+         *     }
+         * return 1;
+         * }
+         */
+        let programs = vec![
+            vec![StatementType::Expression(Expression::Integer(1))],
+            vec![
+                StatementType::Return(Expression::Integer(2)),
+                StatementType::Expression(Expression::Integer(9)),
+            ],
+            vec![
+                StatementType::Return(Expression::Infix {
+                    left: Box::new(Expression::Integer(2)),
+                    op: InfixOp::Asterisk,
+                    right: Box::new(Expression::Integer(3)),
+                }),
+                StatementType::Expression(Expression::Integer(9)),
+            ],
+            vec![
+                StatementType::Expression(Expression::Integer(9)),
+                StatementType::Return(Expression::Infix {
+                    left: Box::new(Expression::Integer(4)),
+                    op: InfixOp::Asterisk,
+                    right: Box::new(Expression::Integer(5)),
+                }),
+                StatementType::Expression(Expression::Integer(9)),
+            ],
+            vec![StatementType::Expression(Expression::If {
+                condition: Box::new(Expression::Infix {
+                    left: Box::new(Expression::Integer(10)),
+                    op: InfixOp::GreaterThan,
+                    right: Box::new(Expression::Integer(1)),
+                }),
+                consequence: Box::new(StatementType::Block(vec![
+                    StatementType::Expression(Expression::If {
+                        condition: Box::new(Expression::Infix {
+                            left: Box::new(Expression::Integer(10)),
+                            op: InfixOp::GreaterThan,
+                            right: Box::new(Expression::Integer(1)),
+                        }),
+                        consequence: Box::new(StatementType::Block(vec![StatementType::Return(
+                            Expression::Integer(100),
+                        )])),
+                        alternative: None,
+                    }),
+                    StatementType::Return(Expression::Integer(1)),
+                ])),
+                alternative: None,
+            })],
+        ];
+        let results = vec![1, 2, 6, 20, 100];
+
+        let rust_eval = rust::RustEvaluator::new();
+
+        for (idx, p) in programs.into_iter().enumerate() {
+            let res = test_eval_program(&rust_eval, &create_program(p))?;
+            assert_eq!(res.inspect(), results[idx].to_string());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_error_handling() -> Result<()> {
+        /*
+         * 5 + true;
+         * 5 + true; 5;
+         * -true;
+         * true + false;
+         * 5; true + false; 5;
+         * if (10 > 1) { true * false; };
+         * if (10 > 1) {
+         *    if (10 > 1) {
+         *    return true - false;
+         *    }
+         *    return 1;
+         * }
+         *  tubias;
+         */
+        let programs = vec![
+            vec![StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Integer(5)),
+                op: InfixOp::Plus,
+                right: Box::new(Expression::Boolean(true)),
+            })],
+            vec![
+                StatementType::Expression(Expression::Infix {
+                    left: Box::new(Expression::Integer(5)),
+                    op: InfixOp::Plus,
+                    right: Box::new(Expression::Boolean(true)),
+                }),
+                StatementType::Expression(Expression::Integer(5)),
+            ],
+            vec![StatementType::Expression(Expression::Prefix {
+                op: PrefixOp::Minus,
+                right: Box::new(Expression::Boolean(true)),
+            })],
+            vec![StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Boolean(true)),
+                op: InfixOp::Plus,
+                right: Box::new(Expression::Boolean(false)),
+            })],
+            vec![
+                StatementType::Expression(Expression::Integer(5)),
+                StatementType::Expression(Expression::Infix {
+                    left: Box::new(Expression::Boolean(true)),
+                    op: InfixOp::Plus,
+                    right: Box::new(Expression::Boolean(false)),
+                }),
+                StatementType::Expression(Expression::Integer(5)),
+            ],
+            vec![StatementType::Expression(Expression::If {
+                condition: Box::new(Expression::Infix {
+                    left: Box::new(Expression::Integer(10)),
+                    op: InfixOp::GreaterThan,
+                    right: Box::new(Expression::Integer(1)),
+                }),
+                consequence: Box::new(StatementType::Block(vec![StatementType::Expression(
+                    Expression::Infix {
+                        left: Box::new(Expression::Boolean(true)),
+                        op: InfixOp::Asterisk,
+                        right: Box::new(Expression::Boolean(false)),
+                    },
+                )])),
+                alternative: None,
+            })],
+            vec![StatementType::Expression(Expression::If {
+                condition: Box::new(Expression::Infix {
+                    left: Box::new(Expression::Integer(10)),
+                    op: InfixOp::GreaterThan,
+                    right: Box::new(Expression::Integer(1)),
+                }),
+                consequence: Box::new(StatementType::Block(vec![
+                    StatementType::Expression(Expression::If {
+                        condition: Box::new(Expression::Infix {
+                            left: Box::new(Expression::Integer(10)),
+                            op: InfixOp::GreaterThan,
+                            right: Box::new(Expression::Integer(1)),
+                        }),
+                        consequence: Box::new(StatementType::Block(vec![StatementType::Return(
+                            Expression::Infix {
+                                left: Box::new(Expression::Boolean(true)),
+                                op: InfixOp::Minus,
+                                right: Box::new(Expression::Boolean(false)),
+                            },
+                        )])),
+                        alternative: None,
+                    }),
+                    StatementType::Return(Expression::Integer(1)),
+                ])),
+                alternative: None,
+            })],
+            vec![StatementType::Expression(Expression::Identifier(
+                "tubias".to_string(),
+            ))],
+        ];
+
+        let errors = vec![
+            EvaluationError::MismatchedTypesInfix {
+                left: Object::Integer(5).type_as_string(),
+                right: Object::Boolean(true).type_as_string(),
+                operator: InfixOp::Plus.type_as_string(),
+            },
+            EvaluationError::MismatchedTypesInfix {
+                left: Object::Integer(5).type_as_string(),
+                right: Object::Boolean(true).type_as_string(),
+                operator: InfixOp::Plus.type_as_string(),
+            },
+            EvaluationError::MissingIntegerToInvert {
+                obj: Object::Boolean(true).type_as_string(),
+            },
+            EvaluationError::UnallowedBooleanComparisonOperator {
+                operator: InfixOp::Plus.type_as_string(),
+            },
+            EvaluationError::UnallowedBooleanComparisonOperator {
+                operator: InfixOp::Plus.type_as_string(),
+            },
+            EvaluationError::UnallowedBooleanComparisonOperator {
+                operator: InfixOp::Asterisk.type_as_string(),
+            },
+            EvaluationError::UnallowedBooleanComparisonOperator {
+                operator: InfixOp::Minus.type_as_string(),
+            },
+            EvaluationError::IdentifierNotFound {
+                identifier: "tubias".to_string(),
+            },
+        ];
+
+        let rust_eval = rust::RustEvaluator::new();
+
+        for (idx, ast) in programs.into_iter().enumerate() {
+            let err = test_eval_program(&rust_eval, &create_program(ast)).unwrap_err();
+            assert_eq!(err.to_string(), errors[idx].to_string());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn eval_let_statements() -> Result<()> {
+        /*
+         * let a = 5; a;
+         * let a = 5 * 5; a;
+         * let a = 5; let b = a; b;
+         * let a = 5; let b = a; let c = a + b + 5; c;
+         */
+        let programs = vec![
+            vec![
+                StatementType::Let {
+                    name: Expression::Identifier("a".to_string()),
+                    value: Expression::Integer(5),
+                },
+                StatementType::Expression(Expression::Identifier("a".to_string())),
+            ],
+            vec![
+                StatementType::Let {
+                    name: Expression::Identifier("a".to_string()),
+                    value: Expression::Infix {
+                        left: Box::new(Expression::Integer(5)),
+                        op: InfixOp::Asterisk,
+                        right: Box::new(Expression::Integer(5)),
+                    },
+                },
+                StatementType::Expression(Expression::Identifier("a".to_string())),
+            ],
+            vec![
+                StatementType::Let {
+                    name: Expression::Identifier("a".to_string()),
+                    value: Expression::Integer(5),
+                },
+                StatementType::Let {
+                    name: Expression::Identifier("b".to_string()),
+                    value: Expression::Identifier("a".to_string()),
+                },
+                StatementType::Expression(Expression::Identifier("b".to_string())),
+            ],
+            vec![
+                StatementType::Let {
+                    name: Expression::Identifier("a".to_string()),
+                    value: Expression::Integer(5),
+                },
+                StatementType::Let {
+                    name: Expression::Identifier("b".to_string()),
+                    value: Expression::Identifier("a".to_string()),
+                },
+                StatementType::Let {
+                    name: Expression::Identifier("c".to_string()),
+                    value: Expression::Infix {
+                        left: Box::new(Expression::Infix {
+                            left: Box::new(Expression::Identifier("a".to_string())),
+                            op: InfixOp::Plus,
+                            right: Box::new(Expression::Identifier("b".to_string())),
+                        }),
+                        op: InfixOp::Plus,
+                        right: Box::new(Expression::Integer(5)),
+                    },
+                },
+                StatementType::Expression(Expression::Identifier("c".to_string())),
+            ],
+        ];
+        let results = vec![5, 25, 5, 15];
+
+        let rust_eval = rust::RustEvaluator::new();
+
+        for (idx, ast) in programs.into_iter().enumerate() {
+            let rust_res = test_eval_program(&rust_eval, &create_program(ast))?;
+            assert_eq!(rust_res.inspect(), results[idx].to_string());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn eval_function_object() -> Result<()> {
+        //fn(x) { x + 2; };
+        let ast = vec![StatementType::Expression(Expression::FunctionLiteral {
+            parameters: vec![Expression::Identifier("x".to_string())],
+            block: Box::new(StatementType::Block(vec![StatementType::Expression(
+                Expression::Infix {
+                    left: Box::new(Expression::Identifier("x".to_string())),
+                    op: InfixOp::Plus,
+                    right: Box::new(Expression::Integer(2)),
+                },
+            )])),
+        })];
+
+        let expect = Object::Function {
+            params: vec![Expression::Identifier("x".to_string())],
+            body: StatementType::Block(vec![StatementType::Expression(Expression::Infix {
+                left: Box::new(Expression::Identifier("x".to_string())),
+                op: InfixOp::Plus,
+                right: Box::new(Expression::Integer(2)),
+            })]),
+            env: Rc::new(RefCell::new(Environment::new())),
+        };
+
+        let rust_eval = rust::RustEvaluator::new();
+
+        let rust_res = test_eval_program(&rust_eval, &create_program(ast))?;
+
+        assert_eq!(rust_res, expect);
+
+        Ok(())
+    }
+
+    #[test]
+    fn eval_function_application() -> Result<()> {
+        /*
+         * let identity = fn(x) { x; }; identity(5);
+         * let identity = fn(x) { return x; }; identity(5);
+         * let double = fn(x) { x * 2; }; double(5);
+         * let add = fn(x, y) { x + y; }; add(5, 5);
+         * let add = fn(x, y) { x + y; }; add(5 + 5, add(5, 5));
+         * fn(x) { x; }(5)
+         */
+        let programs = vec![
+            vec![
+                StatementType::Let {
+                    name: Expression::Identifier("identity".to_string()),
+                    value: Expression::FunctionLiteral {
+                        parameters: vec![Expression::Identifier("x".to_string())],
+                        block: Box::new(StatementType::Block(vec![StatementType::Expression(
+                            Expression::Identifier("x".to_string()),
+                        )])),
+                    },
+                },
+                StatementType::Expression(Expression::Call {
+                    function: Box::new(Expression::Identifier("identity".to_string())),
+                    arguments: vec![Expression::Integer(5)],
+                }),
+            ],
+            vec![
+                StatementType::Let {
+                    name: Expression::Identifier("identity".to_string()),
+                    value: Expression::FunctionLiteral {
+                        parameters: vec![Expression::Identifier("x".to_string())],
+                        block: Box::new(StatementType::Block(vec![StatementType::Return(
+                            Expression::Identifier("x".to_string()),
+                        )])),
+                    },
+                },
+                StatementType::Expression(Expression::Call {
+                    function: Box::new(Expression::Identifier("identity".to_string())),
+                    arguments: vec![Expression::Integer(5)],
+                }),
+            ],
+            vec![
+                StatementType::Let {
+                    name: Expression::Identifier("double".to_string()),
+                    value: Expression::FunctionLiteral {
+                        parameters: vec![Expression::Identifier("x".to_string())],
+                        block: Box::new(StatementType::Block(vec![StatementType::Expression(
+                            Expression::Infix {
+                                left: Box::new(Expression::Identifier("x".to_string())),
+                                op: InfixOp::Asterisk,
+                                right: Box::new(Expression::Integer(2)),
+                            },
+                        )])),
+                    },
+                },
+                StatementType::Expression(Expression::Call {
+                    function: Box::new(Expression::Identifier("double".to_string())),
+                    arguments: vec![Expression::Integer(5)],
+                }),
+            ],
+            vec![
+                StatementType::Let {
+                    name: Expression::Identifier("add".to_string()),
+                    value: Expression::FunctionLiteral {
+                        parameters: vec![
+                            Expression::Identifier("x".to_string()),
+                            Expression::Identifier("y".to_string()),
+                        ],
+                        block: Box::new(StatementType::Block(vec![StatementType::Expression(
+                            Expression::Infix {
+                                left: Box::new(Expression::Identifier("x".to_string())),
+                                op: InfixOp::Plus,
+                                right: Box::new(Expression::Identifier("y".to_string())),
+                            },
+                        )])),
+                    },
+                },
+                StatementType::Expression(Expression::Call {
+                    function: Box::new(Expression::Identifier("add".to_string())),
+                    arguments: vec![Expression::Integer(5), Expression::Integer(5)],
+                }),
+            ],
+            vec![
+                StatementType::Let {
+                    name: Expression::Identifier("add".to_string()),
+                    value: Expression::FunctionLiteral {
+                        parameters: vec![
+                            Expression::Identifier("x".to_string()),
+                            Expression::Identifier("y".to_string()),
+                        ],
+                        block: Box::new(StatementType::Block(vec![StatementType::Expression(
+                            Expression::Infix {
+                                left: Box::new(Expression::Identifier("x".to_string())),
+                                op: InfixOp::Plus,
+                                right: Box::new(Expression::Identifier("y".to_string())),
+                            },
+                        )])),
+                    },
+                },
+                StatementType::Expression(Expression::Call {
+                    function: Box::new(Expression::Identifier("add".to_string())),
+                    arguments: vec![
+                        Expression::Infix {
+                            left: Box::new(Expression::Integer(5)),
+                            op: InfixOp::Plus,
+                            right: Box::new(Expression::Integer(5)),
+                        },
+                        Expression::Call {
+                            function: Box::new(Expression::Identifier("add".to_string())),
+                            arguments: vec![Expression::Integer(5), Expression::Integer(5)],
+                        },
+                    ],
+                }),
+            ],
+            vec![StatementType::Expression(Expression::Call {
+                function: Box::new(Expression::FunctionLiteral {
+                    parameters: vec![Expression::Identifier("x".to_string())],
+                    block: Box::new(StatementType::Block(vec![StatementType::Expression(
+                        Expression::Identifier("x".to_string()),
+                    )])),
+                }),
+                arguments: vec![Expression::Integer(5)],
+            })],
+        ];
+
+        let results = vec![5, 5, 10, 10, 20, 5];
+
+        let rust_eval = rust::RustEvaluator::new();
+
+        for (idx, ast) in programs.into_iter().enumerate() {
+            let rust_res = test_eval_program(&rust_eval, &create_program(ast))?;
+            assert_eq!(rust_res.inspect(), results[idx].to_string());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn eval_function_with_invalid_parameters() -> Result<()> {
+        /*
+         * let addTwo(a,b){ return a + b; }; addTwo();
+         * let addTwo(a,b){ return a + b; }; addTwo(1);
+         */
+        let programs = vec![
+            vec![
+                StatementType::Let {
+                    name: Expression::Identifier("addTwo".to_string()),
+                    value: Expression::FunctionLiteral {
+                        parameters: vec![
+                            Expression::Identifier("a".to_string()),
+                            Expression::Identifier("b".to_string()),
+                        ],
+                        block: Box::new(StatementType::Block(vec![StatementType::Return(
+                            Expression::Infix {
+                                left: Box::new(Expression::Identifier("a".to_string())),
+                                op: InfixOp::Plus,
+                                right: Box::new(Expression::Identifier("b".to_string())),
+                            },
+                        )])),
+                    },
+                },
+                StatementType::Expression(Expression::Call {
+                    function: Box::new(Expression::Identifier("addTwo".to_string())),
+                    arguments: vec![],
+                }),
+            ],
+            vec![
+                StatementType::Let {
+                    name: Expression::Identifier("addTwo".to_string()),
+                    value: Expression::FunctionLiteral {
+                        parameters: vec![
+                            Expression::Identifier("a".to_string()),
+                            Expression::Identifier("b".to_string()),
+                        ],
+                        block: Box::new(StatementType::Block(vec![StatementType::Return(
+                            Expression::Infix {
+                                left: Box::new(Expression::Identifier("a".to_string())),
+                                op: InfixOp::Plus,
+                                right: Box::new(Expression::Identifier("b".to_string())),
+                            },
+                        )])),
+                    },
+                },
+                StatementType::Expression(Expression::Call {
+                    function: Box::new(Expression::Identifier("addTwo".to_string())),
+                    arguments: vec![Expression::Integer(1)],
+                }),
+            ],
+        ];
+
+        let errors = vec![
+            EvaluationError::WrongNumberOfArguments {
+                expected: 2,
+                found: 0,
+            },
+            EvaluationError::WrongNumberOfArguments {
+                expected: 2,
+                found: 1,
+            },
+        ];
+
+        let rust_eval = rust::RustEvaluator::new();
+
+        for (idx, ast) in programs.into_iter().enumerate() {
+            let err = test_eval_program(&rust_eval, &create_program(ast)).unwrap_err();
+            assert_eq!(err.to_string(), errors[idx].to_string());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn eval_recursion() -> Result<()> {
+        /*
+         * let factorial = fn(n) { if (n == 0) { 1 } else { n * factorial(n - 1) } }; factorial(5);
+         * let fibonacci = fn(x) { if (x == 0) { 0 } else { if (x == 1) { 1 } else { fibonacci(x - 1) + fibonacci(x - 2) } } }; fibonacci(10);
+         */
+        let programs = vec![vec![
+            StatementType::Let {
+                name: Expression::Identifier("factorial".to_string()),
+                value: Expression::FunctionLiteral {
+                    parameters: vec![Expression::Identifier("n".to_string())],
+                    block: Box::new(StatementType::Block(vec![StatementType::Expression(
+                        Expression::If {
+                            condition: Box::new(Expression::Infix {
+                                left: Box::new(Expression::Identifier("n".to_string())),
+                                op: InfixOp::Equal,
+                                right: Box::new(Expression::Integer(0)),
+                            }),
+                            consequence: Box::new(StatementType::Block(vec![
+                                StatementType::Expression(Expression::Integer(1)),
+                            ])),
+                            alternative: Some(Box::new(StatementType::Block(vec![
+                                StatementType::Expression(Expression::Infix {
+                                    left: Box::new(Expression::Identifier("n".to_string())),
+                                    op: InfixOp::Asterisk,
+                                    right: Box::new(Expression::Call {
+                                        function: Box::new(Expression::Identifier(
+                                            "factorial".to_string(),
+                                        )),
+                                        arguments: vec![Expression::Infix {
+                                            left: Box::new(Expression::Identifier("n".to_string())),
+                                            op: InfixOp::Minus,
+                                            right: Box::new(Expression::Integer(1)),
+                                        }],
+                                    }),
+                                }),
+                            ]))),
+                        },
+                    )])),
+                },
+            },
+            StatementType::Expression(Expression::Call {
+                function: Box::new(Expression::Identifier("factorial".to_string())),
+                arguments: vec![Expression::Integer(5)],
+            }),
+        ]];
+        let results = vec![120];
+
+        let rust_eval = rust::RustEvaluator::new();
+
+        for (idx, ast) in programs.into_iter().enumerate() {
+            let rust_res = test_eval_program(&rust_eval, &create_program(ast))?;
+            assert_eq!(rust_res.inspect(), results[idx].to_string());
+        }
+
+        Ok(())
+    }
+}

--- a/src/inter/evaluator.rs
+++ b/src/inter/evaluator.rs
@@ -60,7 +60,6 @@ mod test {
     fn test_eval_program(eval: &dyn Evaluator, prog: &ast::Program) -> Result<Object> {
         let mut e = Environment::new();
         let res = eval.eval(prog, &mut e)?;
-        println!("e: {:?}", e);
         Ok(res)
     }
 

--- a/src/inter/evaluator/rust.rs
+++ b/src/inter/evaluator/rust.rs
@@ -1,0 +1,264 @@
+use std::{cell::RefCell, rc::Rc};
+
+use crate::inter::{
+    ast::expression::{InfixOp, PrefixOp},
+    environment::Environment,
+    object::Object,
+};
+
+use super::ast::*;
+use anyhow::{bail, Result};
+pub struct RustEvaluator {}
+
+impl RustEvaluator {
+    pub fn new() -> Self {
+        RustEvaluator {}
+    }
+
+    fn map_boolean(&self, b: bool) -> Object {
+        if b {
+            super::TRUE
+        } else {
+            super::FALSE
+        }
+    }
+
+    fn eval_bang_operator(&self, right: Object) -> Result<Object> {
+        match right {
+            Object::Boolean(true) => Ok(super::FALSE),
+            Object::Boolean(false) => Ok(super::TRUE),
+            Object::Null => Ok(super::TRUE),
+            _ => Ok(super::FALSE),
+        }
+    }
+
+    fn eval_minus_operator(&self, right: Object) -> Result<Object> {
+        match right {
+            Object::Integer(i) => Ok(Object::Integer(-i)),
+            _ => bail!(super::EvaluationError::MissingIntegerToInvert {
+                obj: right.type_as_string()
+            }),
+        }
+    }
+
+    fn eval_prefix_expression(
+        &self,
+        op: &PrefixOp,
+        right: &Expression,
+        e: &mut Environment,
+    ) -> Result<Object> {
+        let right = self.eval_expression(right, e)?;
+        match *op {
+            PrefixOp::Bang => self.eval_bang_operator(right),
+            PrefixOp::Minus => self.eval_minus_operator(right),
+        }
+    }
+
+    fn eval_infix_expression(
+        &self,
+        left: &Expression,
+        op: &InfixOp,
+        right: &Expression,
+        e: &mut Environment,
+    ) -> Result<Object> {
+        let left = self.eval_expression(left, e)?;
+        let right = self.eval_expression(right, e)?;
+
+        match (&left, &right, &op) {
+            (Object::Integer(l), Object::Integer(r), o) => match o {
+                InfixOp::Plus => Ok(Object::Integer(l + r)),
+                InfixOp::Minus => Ok(Object::Integer(l - r)),
+                InfixOp::Asterisk => Ok(Object::Integer(l * r)),
+                InfixOp::Slash => Ok(Object::Integer(l / r)),
+                InfixOp::LessThan => Ok(self.map_boolean(l < r)),
+                InfixOp::GreaterThan => Ok(self.map_boolean(l > r)),
+                InfixOp::Equal => Ok(self.map_boolean(l == r)),
+                InfixOp::NotEqual => Ok(self.map_boolean(l != r)),
+            },
+            (Object::Boolean(l), Object::Boolean(r), o) => match o {
+                InfixOp::Equal => Ok(self.map_boolean(l == r)),
+                InfixOp::NotEqual => Ok(self.map_boolean(l != r)),
+                _ => bail!(super::EvaluationError::UnallowedBooleanComparisonOperator {
+                    operator: op.type_as_string(),
+                }),
+            },
+            _ => bail!(super::EvaluationError::MismatchedTypesInfix {
+                left: left.type_as_string(),
+                right: right.type_as_string(),
+                operator: op.type_as_string(),
+            }),
+        }
+    }
+
+    fn is_truthy(&self, obj: &Object) -> bool {
+        match obj {
+            Object::Null => false,
+            Object::Boolean(b) => *b,
+            _ => true,
+        }
+    }
+
+    fn eval_if_expression(
+        &self,
+        cond: &Expression,
+        cons: &StatementType,
+        alt: &Option<Box<StatementType>>,
+        e: &mut Environment,
+    ) -> Result<Object> {
+        let condition = self.eval_expression(cond, e)?;
+        match (self.is_truthy(&condition), alt) {
+            (true, _) => Ok(self.eval_statements(cons, e)?),
+            (false, Some(a)) => Ok(self.eval_statements(a, e)?),
+            (false, None) => Ok(super::NULL),
+        }
+    }
+
+    fn eval_let_statement(
+        &self,
+        name: &Expression,
+        value: &Expression,
+        e: &mut Environment,
+    ) -> Result<Object> {
+        let value = self.eval_expression(value, e)?;
+        e.set(name, value.clone())?;
+        Ok(value)
+    }
+
+    fn eval_expressions(&self, params: &[Expression], e: &mut Environment) -> Result<Vec<Object>> {
+        let mut args = Vec::with_capacity(params.len());
+        for p in params {
+            let p = self.eval_expression(p, e)?;
+            args.push(p);
+        }
+        Ok(args)
+    }
+
+    fn eval_fn_call(
+        &self,
+        function: &Expression,
+        arguments: &[Expression],
+        e: &mut Environment,
+    ) -> Result<Object> {
+        let func = self.eval_expression(function, e)?;
+
+        match func {
+            Object::Function {
+                params,
+                body,
+                env: f_env,
+            } => {
+                let args = self.eval_expressions(arguments, e)?;
+
+                if args.len() != params.len() {
+                    bail!(super::EvaluationError::WrongNumberOfArguments {
+                        expected: params.len(),
+                        found: args.len(),
+                    });
+                };
+
+                let mut extended_env = Environment::new_with_outer(Rc::clone(&f_env));
+                extended_env.set_arguments_to_env(args, params.clone())?;
+
+                if let Expression::Identifier(_) = function {
+                    extended_env.set(
+                        function,
+                        Object::Function {
+                            params,
+                            body: body.clone(),
+                            env: f_env,
+                        },
+                    )?;
+                }
+
+                let evaluated = self.eval_statements(&body, &mut extended_env)?;
+
+                if let Object::ReturnValue(v) = evaluated {
+                    Ok(*v)
+                } else {
+                    Ok(evaluated)
+                }
+            }
+            _ => bail!(super::EvaluationError::NotAFunction {
+                found: func.type_as_string(),
+            }),
+        }
+    }
+
+    fn eval_expression(&self, expr: &Expression, e: &mut Environment) -> Result<Object> {
+        match *expr {
+            Expression::Integer(i) => Ok(Object::Integer(i)),
+            Expression::Boolean(b) => Ok(self.map_boolean(b)),
+            Expression::Prefix { ref op, ref right } => {
+                Ok(self.eval_prefix_expression(op, right, e)?)
+            }
+            Expression::Infix {
+                ref left,
+                ref op,
+                ref right,
+            } => Ok(self.eval_infix_expression(left, op, right, e)?),
+            Expression::If {
+                ref condition,
+                ref consequence,
+                ref alternative,
+            } => Ok(self.eval_if_expression(condition, consequence, alternative, e)?),
+            Expression::Identifier(ref name) => Ok(e.get(name)?),
+            Expression::FunctionLiteral {
+                ref parameters,
+                ref block,
+            } => Ok(Object::Function {
+                params: parameters.clone(),
+                body: *block.clone(),
+                env: Rc::new(RefCell::new(e.clone())),
+            }),
+            Expression::Call {
+                ref function,
+                ref arguments,
+            } => self.eval_fn_call(function, arguments, e),
+        }
+    }
+
+    fn eval_block_statements(
+        &self,
+        stmts: &[super::ast::StatementType],
+        e: &mut Environment,
+    ) -> Result<Object> {
+        let mut res = Object::Null;
+        for stmt in stmts.iter() {
+            res = self.eval_statements(stmt, e)?;
+            if let Object::ReturnValue(_) = res {
+                return Ok(res);
+            }
+        }
+        Ok(res)
+    }
+    fn eval_statements(
+        &self,
+        node: &super::ast::StatementType,
+        e: &mut Environment,
+    ) -> Result<super::Object> {
+        match *node {
+            StatementType::Expression(ref expr) => self.eval_expression(expr, e),
+            StatementType::Block(ref block) => self.eval_block_statements(block, e),
+            StatementType::Return(ref expr) => Ok(Object::ReturnValue(Box::new(
+                self.eval_expression(expr, e)?,
+            ))),
+            StatementType::Let {
+                ref name,
+                ref value,
+            } => self.eval_let_statement(name, value, e),
+        }
+    }
+}
+
+impl super::Evaluator for RustEvaluator {
+    fn eval(&self, prog: &Program, e: &mut Environment) -> Result<super::Object> {
+        let mut res = Object::Null;
+        for stmt in prog.statements.iter() {
+            res = self.eval_statements(stmt, e)?;
+            if let Object::ReturnValue(v) = res {
+                return Ok(*v);
+            }
+        }
+        Ok(res)
+    }
+}

--- a/src/inter/object.rs
+++ b/src/inter/object.rs
@@ -1,13 +1,11 @@
 use std::{cell::RefCell, fmt, rc::Rc};
 
-use enum_as_inner::EnumAsInner;
-
 use crate::inter::{
     ast::{Expression, StatementType},
     environment::Environment,
 };
 
-#[derive(Debug, PartialEq, EnumAsInner, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Object {
     Integer(i64),
     Boolean(bool),

--- a/src/inter/object.rs
+++ b/src/inter/object.rs
@@ -1,0 +1,56 @@
+use std::{cell::RefCell, fmt, rc::Rc};
+
+use enum_as_inner::EnumAsInner;
+
+use crate::inter::{
+    ast::{Expression, StatementType},
+    environment::Environment,
+};
+
+#[derive(Debug, PartialEq, EnumAsInner, Clone)]
+pub enum Object {
+    Integer(i64),
+    Boolean(bool),
+    ReturnValue(Box<Object>),
+    Null,
+    Function {
+        params: Vec<Expression>,
+        body: StatementType,
+        env: Rc<RefCell<Environment>>,
+    },
+}
+
+impl Object {
+    pub fn inspect(&self) -> String {
+        match self {
+            Object::Integer(i) => i.to_string(),
+            Object::Boolean(b) => b.to_string(),
+            Object::Null => String::from("null"),
+            Object::ReturnValue(v) => v.inspect(),
+            Object::Function { .. } => "".to_string(),
+        }
+    }
+
+    pub fn type_as_string(&self) -> &'static str {
+        match self {
+            Object::Integer(_) => "Integer",
+            Object::Boolean(_) => "Boolean",
+            Object::Null => "Null",
+            Object::ReturnValue(_) => "ReturnValue",
+            Object::Function { .. } => "Function",
+        }
+    }
+}
+
+impl fmt::Display for Object {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let buf = match self {
+            Object::Integer(v) => v.to_string(),
+            Object::Boolean(v) => v.to_string(),
+            Object::Null => String::from("null"),
+            Object::ReturnValue(v) => v.to_string(),
+            Object::Function { .. } => String::from("fn"),
+        };
+        write!(f, "{}", buf)
+    }
+}

--- a/src/inter/tokens.rs
+++ b/src/inter/tokens.rs
@@ -1,10 +1,8 @@
 use core::fmt;
 
-use enum_as_inner::EnumAsInner;
-
 pub type TokenType = Token;
 
-#[derive(Debug, PartialEq, Clone, EnumAsInner)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Token {
     Ident(String),
     Integer(String),


### PR DESCRIPTION
# Changelog: 
- remove prefix type_as_string
- remove EnumAsInner from Object
- remove EnumAsInner from Token
- remove enum-as-inner as dependency
- add Object file
- add evaluator trait and constant values
- add rust_evaluator
- add custom_evaluator
- add eval_integer, eval_boolean, eval_bang, eval_minus
- add type_as_string to Object and impl Display for Object
- add eval_infix_expressions
- add if_else_statements tests
- add eval_block_statements to evaluator trait
- add eval_if_else_statements in rust evaluator
- add ReturnValue to Object
- add evalt_return_statements test
- add eval_return_value to rust evaluator
- add UnallowedPrefixOperator for EvaluationError
- add test_error_handling to evaluator
- add Environment file
- derive Clone to Expression and StatetementType
- make repl use evaluator
- add recursion tests
- make expression pub in ast
- impl display for infixop
- add type_as_string to InfixOp
- add type_as_String to PrefixOp
- add type_as_string to Expression